### PR TITLE
Package version updated in Project file

### DIFF
--- a/src/MauiBlazor.Markup/MauiBlazor.Markup/MauiBlazor.Markup.csproj
+++ b/src/MauiBlazor.Markup/MauiBlazor.Markup/MauiBlazor.Markup.csproj
@@ -36,7 +36,7 @@
 		<PackageTags>.NET,MAUI,Blazor,BlazorWebView,C#,Markup,Fluent,API,Declarative,Hybrid</PackageTags>
 		<PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/release-notes.txt"))</PackageReleaseNotes>
 		<AssemblyName>VijayAnand.MauiBlazor.Markup</AssemblyName>
-		<Version>1.0.0</Version>
+		<Version>1.0.0-pre5</Version>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<FileVersion>1.0.0.0</FileVersion>
 		<PackageReadmeFile>overview.md</PackageReadmeFile>


### PR DESCRIPTION
Since the Windows build is not working from the `dotnet CLI`, the package version is updated in the project file to proceed with VS build.